### PR TITLE
add 'square pixel' aspect ratio option, add 640x400 res option, impro…

### DIFF
--- a/src/PSP2/prefs_editor_psp.cpp
+++ b/src/PSP2/prefs_editor_psp.cpp
@@ -244,7 +244,7 @@ void psp_create_floppy(void *arg)
 	struct gui_list psp_aspect_list[] = {
 		{ "4:3", 0 },
 		{ "16:9", 1 },
-        { "square pixels", 2},
+        { "Fit", 2},
 		{ 0, GUI_END_OF_LIST }
 	};
 

--- a/src/PSP2/prefs_editor_psp.cpp
+++ b/src/PSP2/prefs_editor_psp.cpp
@@ -46,7 +46,7 @@ extern char *RequestString (char *initialStr);
  */
 
 // prefs with default values
-int psp_screen_mode = 1; // 640x480
+int psp_screen_mode = 4; // 726x544
 int psp_screen_depth = 1; // 256 color
 int psp_screen_rate = 0; // 60 Hz
 int psp_sound_enable = 1; // sound on
@@ -244,6 +244,7 @@ void psp_create_floppy(void *arg)
 	struct gui_list psp_aspect_list[] = {
 		{ "4:3", 0 },
 		{ "16:9", 1 },
+        { "square pixels", 2},
 		{ 0, GUI_END_OF_LIST }
 	};
 
@@ -390,10 +391,11 @@ void psp_create_floppy(void *arg)
 	struct gui_list gfx_screen_list[] = {
 		{ "512x384", 0 },
 		{ "640x360", 1 },
-		{ "640x480", 2 },
-		{ "726x544", 3 },
-		{ "768x432", 3 },
-		{ "768x576", 4 },
+		{ "640x400", 2 },
+		{ "640x480", 3 },
+		{ "726x544", 4 },
+		{ "768x432", 5 },
+		{ "768x576", 6 },
 		{ 0, GUI_END_OF_LIST }
 	};
 
@@ -467,14 +469,16 @@ bool PrefsEditor(void)
             psp_screen_mode = 0;
         else if (width == 640 && height == 360)
             psp_screen_mode = 1;
-        else if (width == 640 && height == 480)
+        else if (width == 640 && height == 400)
             psp_screen_mode = 2;
-         else if (width == 726 && height == 544)
+        else if (width == 640 && height == 480)
             psp_screen_mode = 3;
-        else if (width == 768 && height == 432)
+         else if (width == 726 && height == 544)
             psp_screen_mode = 4;
-        else if (width == 768 && height == 576)
+        else if (width == 768 && height == 432)
             psp_screen_mode = 5;
+        else if (width == 768 && height == 576)
+            psp_screen_mode = 6;
         switch (depth)
         {
             case 4:
@@ -577,9 +581,10 @@ bool PrefsEditor(void)
 
     // set prefs from final values
 
-    char scrnmodes[6][4][12] = {
+    char scrnmodes[7][4][12] = {
         { "512/384/4", "512/384/8", "512/384/15", "512/384/24" },
         { "640/360/4", "640/360/8", "640/360/15", "640/360/24" },
+        { "640/400/4", "640/400/8", "640/400/15", "640/400/24" },
         { "640/480/4", "640/480/8", "640/480/15", "640/480/24" },
         { "726/544/4", "726/544/8", "726/544/15", "726/544/24" },
         { "768/432/4", "768/432/8", "768/432/15", "768/432/24" },

--- a/src/PSP2/video_psp.cpp
+++ b/src/PSP2/video_psp.cpp
@@ -349,8 +349,8 @@ driver_fullscreen::driver_fullscreen(PSP_monitor_desc &m)
     psp_screen_y = height;
     psp_screen_d = mode.depth;
     if (psp_lcd_aspect == 2 ) {
-        //square-pixels: fill the screen vertically
-        //and adjust width by same scaling ratio
+        //fit: fill the screen vertically
+        //and adjust width by same scaling ratio to give square pixels
         d_w = psp_screen_x*d_h*1.0/psp_screen_y;
         d_x = (960-d_w)/2.0;
     }
@@ -497,14 +497,15 @@ bool VideoInit(bool classic)
     switch (psp_lcd_aspect)
     {
     case 1:
-        //fullscreen stretch
+        //16:9
         d_w = 960;
         d_h = 544;
         d_x = 0;
         d_y = 0;
         break;
     case 2:
-        //square pixels: d_w and d_x will be adjusted later
+        //fit: d_w will be adjusted later to get square pixels
+        //and d_x will be adjusted later to center the image
         d_w = 960;
         d_h = 544;
         d_x = 0;

--- a/src/PSP2/video_psp.cpp
+++ b/src/PSP2/video_psp.cpp
@@ -251,10 +251,12 @@ static void add_video_modes(video_depth vdepth)
 {
 	add_mode(512, 384, 0x80, PSPBytesPerRow(512, vdepth), vdepth);
 	add_mode(640, 360, 0x81, PSPBytesPerRow(640, vdepth), vdepth);
-	add_mode(640, 480, 0x82, PSPBytesPerRow(640, vdepth), vdepth);
-	add_mode(726, 544, 0x83, PSPBytesPerRow(726, vdepth), vdepth);
-	add_mode(768, 432, 0x84, PSPBytesPerRow(768, vdepth), vdepth);
-	add_mode(768, 576, 0x85, PSPBytesPerRow(768, vdepth), vdepth);
+	add_mode(640, 400, 0x82, PSPBytesPerRow(640, vdepth), vdepth);
+	add_mode(640, 480, 0x83, PSPBytesPerRow(640, vdepth), vdepth);
+	add_mode(726, 544, 0x84, PSPBytesPerRow(726, vdepth), vdepth);
+	add_mode(768, 432, 0x85, PSPBytesPerRow(768, vdepth), vdepth);
+	add_mode(768, 576, 0x86, PSPBytesPerRow(768, vdepth), vdepth);
+
 }
 
 // Set Mac frame layout and base address (uses the_buffer/MacFrameBaseMac)
@@ -346,6 +348,12 @@ driver_fullscreen::driver_fullscreen(PSP_monitor_desc &m)
     psp_screen_x = width;
     psp_screen_y = height;
     psp_screen_d = mode.depth;
+    if (psp_lcd_aspect == 2 ) {
+        //square-pixels: fill the screen vertically
+        //and adjust width by same scaling ratio
+        d_w = psp_screen_x*d_h*1.0/psp_screen_y;
+        d_x = (960-d_w)/2.0;
+    }
     scale_x = d_w*1.0/psp_screen_x;
     scale_y = d_h*1.0/psp_screen_y;
 
@@ -423,7 +431,9 @@ static void keycode_init(void)
 void psp_video_setup(void)
 {
     screen = vita2d_create_empty_texture_format(768, 576, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
-	screen_data = (unsigned int*)vita2d_texture_get_datap(screen);
+    // set filters to improve image quality in case the mac pixel to screen pixel mapping is not 1:1
+    vita2d_texture_set_filters(screen, SCE_GXM_TEXTURE_FILTER_LINEAR, SCE_GXM_TEXTURE_FILTER_LINEAR);
+    screen_data = (unsigned int*)vita2d_texture_get_datap(screen);
 
     vita2d_start_drawing();
     vita2d_clear_screen();
@@ -484,15 +494,24 @@ bool VideoInit(bool classic)
     SCR_HEIGHT = 544;
     DISP_BUF = 0;
 
-    if (psp_lcd_aspect)
+    switch (psp_lcd_aspect)
     {
+    case 1:
+        //fullscreen stretch
         d_w = 960;
         d_h = 544;
         d_x = 0;
         d_y = 0;
-    }
-    else
-    {
+        break;
+    case 2:
+        //square pixels: d_w and d_x will be adjusted later
+        d_w = 960;
+        d_h = 544;
+        d_x = 0;
+        d_y = 0;
+        break;
+    default: 
+        //4:3
         d_w = 726;
         d_h = 544;
         d_x = (960-726)/2;
@@ -515,19 +534,21 @@ bool VideoInit(bool classic)
 		default_mode = 0x80;
 	else if ((default_width == 640) && (default_height == 360))
 		default_mode = 0x81;
-	else if ((default_width == 640) && (default_height == 480))
+	else if ((default_width == 640) && (default_height == 400))
 		default_mode = 0x82;
-    else if ((default_width == 726) && (default_height == 544))
+	else if ((default_width == 640) && (default_height == 480))
 		default_mode = 0x83;
-	else if ((default_width == 768) && (default_height == 432))
+    else if ((default_width == 726) && (default_height == 544))
 		default_mode = 0x84;
-	else if ((default_width == 768) && (default_height == 576))
+	else if ((default_width == 768) && (default_height == 432))
 		default_mode = 0x85;
+	else if ((default_width == 768) && (default_height == 576))
+		default_mode = 0x86;
 	else {
-			default_width = 640;
-			default_height = 480;
+			default_width = 726;
+			default_height = 544;
 			default_depth = 8;
-			default_mode = 0x81;
+			default_mode = 0x84;
 	}
 
 	video_depth default_vdepth;
@@ -552,6 +573,7 @@ bool VideoInit(bool classic)
 
 	// Construct list of supported modes
 	add_video_modes(VDEPTH_4BIT);
+	add_video_modes(VDEPTH_8BIT);
 	add_video_modes(VDEPTH_8BIT);
 	add_video_modes(VDEPTH_16BIT);
 	add_video_modes(VDEPTH_32BIT);

--- a/src/PSP2/video_psp.cpp
+++ b/src/PSP2/video_psp.cpp
@@ -574,7 +574,6 @@ bool VideoInit(bool classic)
 	// Construct list of supported modes
 	add_video_modes(VDEPTH_4BIT);
 	add_video_modes(VDEPTH_8BIT);
-	add_video_modes(VDEPTH_8BIT);
 	add_video_modes(VDEPTH_16BIT);
 	add_video_modes(VDEPTH_32BIT);
 


### PR DESCRIPTION
…ve image render quality for resolutions when pixels are not mapped 1:1 to Vita screen

- add 640x400 resolution option (specifically to display some games fullscreen without stretching)
- add aspect ratio option "square pixels," useful to achieve a larger display of some fullscreen games without distortion. For example, fullscreen games that run in 640x400 fit the Vita screen pretty well, even without stretching to 16:9.
- improve picture quality for resolutions where mac pixels do not map 1:1 onto vita pixels. Pixels are much less distorted now in those cases.

Note the OS resolution choice has higher priority than Basiliskii settings. So, to change resolution, it is not enough to only change it in the Basilisk prefs. The os will set it back during boot. It has to be changed also in the "monitors" extension in system 7.