### PR TITLE
reduce bluetooth mouse lag

### DIFF
--- a/src/PSP2/main_psp.cpp
+++ b/src/PSP2/main_psp.cpp
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
     psvDebugScreenSetFgColor(0xFFFFFFFF);
     psvDebugScreenClear(0xFF000000);
 
-	sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
+	sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG_WIDE);
     sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
 
     // Print some info

--- a/src/PSP2/video_psp.cpp
+++ b/src/PSP2/video_psp.cpp
@@ -1183,7 +1183,7 @@ void VideoInterrupt(void)
     uint32 fc = 0xFF8888FF;
     static int stick[16] = { -8, -8, -6, -4, -2, -1, -1, 0, 0, 0, 1, 1, 2, 4, 6, 8 };
 
-	sceCtrlReadBufferPositive(0, &pad, 1);
+	sceCtrlPeekBufferPositive(0, &pad, 1);
 	sceTouchPeek(0, &touch, 1);
     buttons = pad.buttons ^ oldButtons; // set if button changed
     oldButtons = pad.buttons;
@@ -1295,9 +1295,9 @@ void VideoInterrupt(void)
         {
 			ADBSetRelMouseMode(true);
 			int i = 0;
-			for (int i = 0; i < ret; i++)
-			{
-				ADBMouseMoved(m_reports[i].rel_x*2, m_reports[i].rel_y*2);
+
+			if (m_reports[0].rel_x || m_reports[0].rel_y) {
+				ADBMouseMoved(m_reports[0].rel_x*2, m_reports[0].rel_y*2);
 			}
 
 			if (m_reports[i].buttons & 0x1) { //Left mouse button


### PR DESCRIPTION
Using a bluetooth mouse to move the mouse pointer results in some lag in the pointer motion. All other controls are fine. This is an attempt to reduce that delay.

Changed:
- Use "Peek" instead of "Read" when accessing controller data (peek is supposed to be faster) 
- Only read one bluetooth mouse motion report each time the mouse is queried (the mouse read function is called often enough so that we do not need to check every report from the past)