### PR TITLE
implement slow/fast modifiers for analog pointer, allow more memory

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -287,6 +287,11 @@ For multi-touch gestures, the fingers have to be far enough apart from each othe
 Changelog 
 -----------
 
+0.33h
+
+- implement slow/fast modifiers for analog pointer
+- allow more memory (>29 MB) for emulated computer
+
 0.33g
 
 - further improve pointer motion with analog stick

--- a/README.MD
+++ b/README.MD
@@ -101,6 +101,17 @@ LTRIGGER – option key
 UP/DOWN/LEFT/RIGHT – corresponding cursor key  
 ANALOG STICK – mouse  
 
+analog_speed Controls
+================
+CROSS – mouse button  
+SQUARE – enter key  
+CIRCLE – control key + mouse button ("right click")
+TRIANGLE – command + q (Quit Application)  
+RTRIGGER – hold to slow down analog joystick mouse
+LTRIGGER – hold to speed up analog joystick mouse
+UP/DOWN/LEFT/RIGHT – corresponding cursor key  
+ANALOG STICK – mouse  
+
 dpad_mouse Controls
 ===================
 CROSS – mouse button  
@@ -256,6 +267,8 @@ Basilisk II Key Codes
 122     F1
 255     No key press
 256     Mouse button 1
+1024	Slow down analog stick mouse
+1025	Speed up analog stick mouse
 `````
 
 Indirect Touch Controls

--- a/src/PSP2/makefile
+++ b/src/PSP2/makefile
@@ -22,7 +22,7 @@ INCLUDES = -I../include -I./include -I. -I../uae_cpu -I../uae_cpu/fpu/softfloat
 LIBS = -lSceCtrl_stub -lSceTouch_stub -lSceLibKernel_stub -lSceAudio_stub -lSceNetCtl_stub \
 	-lSceNet_stub -lvita2d -lSceDisplay_stub -lSceSysmodule_stub -lSceGxm_stub \
 	-lScePgf_stub -lScePvf_stub -lSceHid_stub -lScePower_stub -lSceAppUtil_stub \
-	-lSceCommonDialog_stub -lSceIme_stub -lfreetype -lpng -ljpeg -lz -lm -lc
+	-lSceCommonDialog_stub -lSceIme_stub -lSceAppMgr_stub -lfreetype -lpng -ljpeg -lz -lm -lc
 
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc

--- a/src/PSP2/prefs_editor_psp.cpp
+++ b/src/PSP2/prefs_editor_psp.cpp
@@ -91,6 +91,7 @@ extern char psp_home[256];
 // Memory support code
 
 #define MEMORY_USER_SIZE 0x04000000
+int _newlib_heap_size_user = 192 * 1024 * 1024;
 
 static uint32 memFreeSpace(uint32 inAccuracy) {
      if(!inAccuracy)


### PR DESCRIPTION
Use key code 1024 (1025) to map a Vita button to slow down (speed up) analog joystick pointer control when held. This works quite well to position the pointer precisely with the analog stick, even over very small buttons.

imap file example "analog_speed":
```
# Basiliskii Vita input map extended with
# slow/fast analog pointer speed modifiers 
# via holding R/L
#
#    by rsn8887
#
# UP = cursor up
0x0010 0x0000 62 255 255 255
# RIGHT = cursor right
0x0020 0x0000 60 255 255 255
# DOWN = cursor down
0x0040 0x0000 61 255 255 255
# LEFT = cursor left
0x0080 0x0000 59 255 255 255
# LTRIGGER = hold to speed up mouse
0x0100 0x0000 1025 255 255 255
# RTRIGGER = hold to slow down mouse
0x0200 0x0000 1024 255 255 255
# TRIANGLE = command + q
0x1000 0x0000 55 12 255 255
# CIRCLE = control + mouse button 0
0x2000 0x0000 54 256 255 255
# CROSS = mouse button 0
0x4000 0x0000 256 255 255 255
# SQUARE = enter
0x8000 0x0000 36 255 255 255
```
